### PR TITLE
Propsal 1: Replace func_get_args() calls with variable-length arguments

### DIFF
--- a/src/Entities/Keyboard.php
+++ b/src/Entities/Keyboard.php
@@ -32,9 +32,9 @@ use Longman\TelegramBot\Exception\TelegramException;
  */
 class Keyboard extends Entity
 {
-    public function __construct()
+    public function __construct(...$rows)
     {
-        $data = $this->createFromParams(...func_get_args());
+        $data = $this->createFromParams(...$rows);
         parent::__construct($data);
 
         // Remove any empty buttons.
@@ -76,11 +76,11 @@ class Keyboard extends Entity
      *
      * @return array
      */
-    protected function createFromParams(): array
+    protected function createFromParams(...$rows): array
     {
         $keyboard_type = $this->getKeyboardType();
 
-        $args = func_get_args();
+        $args = $rows;
 
         // Force button parameters into individual rows.
         foreach ($args as &$arg) {
@@ -120,9 +120,9 @@ class Keyboard extends Entity
      *
      * @return Keyboard
      */
-    public function addRow(): Keyboard
+    public function addRow(...$buttons): Keyboard
     {
-        if (($new_row = $this->parseRow(func_get_args())) !== null) {
+        if (($new_row = $this->parseRow($buttons)) !== null) {
             $this->{$this->getKeyboardType()}[] = $new_row;
         }
 


### PR DESCRIPTION
<!--
Important:
If this pull request is not related to any issue and contains a new feature, please create an issue first for discussion.
https://github.com/php-telegram-bot/core/issues/new?template=Feature_Request.md

Make sure this pull request is pointed towards the "develop" branch and refers to any issue that it's related to!
-->

<!-- Fill in the relevant information below to help triage your pull request. -->

| ?            |  !
|---           | ---
| Type         | bug / feature / improvement
| BC Break     | yes / no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary of your change. -->
